### PR TITLE
added time, fractional and integral parsers for string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: node_js
 node_js:
   - 0.10
-env:
-  - TAG=v0.7.0
 install:
-  - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
-  - sudo tar zxvf $HOME/purescript.tar.gz -C /usr/local/bin purescript/psc{,i,-docs,-bundle} --strip-components=1
-  - sudo chmod a+x /usr/local/bin/psc{,i,-docs,-bundle}
   - npm install bower gulp phantomjs -g
   - npm install && bower install
 script:

--- a/docs/Data/Json/JSemantic.md
+++ b/docs/Data/Json/JSemantic.md
@@ -1,5 +1,11 @@
 ## Module Data.Json.JSemantic
 
+#### `TimeRec`
+
+``` purescript
+type TimeRec = { hours :: Hours, minutes :: Minutes, seconds :: Seconds, milliseconds :: Milliseconds }
+```
+
 #### `JSemantic`
 
 ``` purescript
@@ -8,12 +14,12 @@ data JSemantic
   | Fractional Number
   | Date Date
   | DateTime Date
-  | Time Date
+  | Time TimeRec
   | Interval Date Date
   | Text String
   | Bool Boolean
   | Percent Number
-  | Currency Number
+  | Currency String Number
   | NA
 ```
 
@@ -23,28 +29,28 @@ instance showJSemantic :: Show JSemantic
 instance eqJSemantic :: Eq JSemantic
 ```
 
-#### `JSemanticRegexes`
+#### `renderJSemantic`
 
 ``` purescript
-type JSemanticRegexes = { percent :: Regex, currency :: Regex, date :: Regex }
+renderJSemantic :: JSemantic -> String
 ```
 
-#### `JSemanticOpts`
+#### `JSemanticParsers`
 
 ``` purescript
-type JSemanticOpts = { regexps :: JSemanticRegexes }
+type JSemanticParsers = { boolParsers :: List (Boolean -> Maybe JSemantic), numberParsers :: List (Number -> Maybe JSemantic), stringParsers :: List (String -> Maybe JSemantic) }
 ```
 
-#### `jSemanticOptsDefault`
+#### `defaultParsers`
 
 ``` purescript
-jSemanticOptsDefault :: JSemanticOpts
+defaultParsers :: JSemanticParsers
 ```
 
 #### `toSemantic`
 
 ``` purescript
-toSemantic :: JSemanticOpts -> JsonPrim -> JSemantic
+toSemantic :: JSemanticParsers -> JsonPrim -> JSemantic
 ```
 
 #### `toSemanticDef`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gulp-plumber": "^1.0.1",
     "gulp-purescript": "^0.5.0",
     "gulp-run": "^1.6.8",
+    "purescript": "^0.7.1",
     "run-sequence": "^1.1.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/src/Data/Json/JSemantic.js
+++ b/src/Data/Json/JSemantic.js
@@ -13,3 +13,7 @@ exports.s2nImpl = function(Just) {
         };
     };
 };
+
+exports.toString = function(d) {
+    return d.toString();
+};

--- a/src/Data/Json/JSemantic.purs
+++ b/src/Data/Json/JSemantic.purs
@@ -1,44 +1,72 @@
 module Data.Json.JSemantic  
-  ( JSemantic(..), JSemanticRegexes(), toSemantic, toSemanticDef
-  , JSemanticOpts(..), jSemanticOptsDefault, renderJSemantic
+  ( JSemantic(..)
+  , JSemanticParsers(..)
+  , TimeRec(..)
+  , toSemantic
+  , toSemanticDef
+  , defaultParsers
+  , renderJSemantic
   ) where
 
 import Prelude
 import Data.Argonaut.JCursor(JsonPrim(..), runJsonPrim)
 import Data.Maybe (Maybe(..), fromMaybe, maybe)
-import Data.Array ((!!))
+import Data.Maybe.First (First(..), runFirst)
+import Data.Foldable (fold)
 import Data.String (split)
 import Data.String.Regex (Regex(..), regex, test, match, noFlags, parseFlags, replace)
 import Data.Int (fromNumber)
 import Control.MonadPlus (guard)
+import Control.Plus (empty)
 import qualified Data.Date as Date
+import qualified Data.Time as Time
+import qualified Data.List as L
+import qualified Data.Array as A 
 import Control.Alt ((<|>))
 import Math (floor)
 
+type TimeRec =
+  { hours :: Time.Hours
+  , minutes :: Time.Minutes
+  , seconds :: Time.Seconds
+  , milliseconds :: Time.Milliseconds
+  } 
 
+timeRecToString :: TimeRec -> String
+timeRecToString { hours: (Time.Hours h)
+                , minutes: (Time.Minutes m)
+                , seconds: (Time.Seconds s)
+                , milliseconds: (Time.Milliseconds ms)
+                } =
+  
+  show h <> ":" <> show m <> ":" <> show s <>
+  (if ms > 0
+   then ("." <> show ms)
+   else "")
+        
 data JSemantic = Integral   Int
                | Fractional Number
-               | Date       Date.Date
-               | DateTime   Date.Date
-               | Time       Date.Date
-               | Interval   Date.Date Date.Date
-               | Text       String
-               | Bool       Boolean
-               | Percent    Number
-               | Currency   Number
+               | Date Date.Date
+               | DateTime Date.Date
+               | Time TimeRec
+               | Interval Date.Date Date.Date
+               | Text String
+               | Bool Boolean
+               | Percent Number
+               | Currency String Number
                | NA
 
 instance showJSemantic :: Show JSemantic where
-  show (Integral   n) = "(Integral " ++ show n ++ ")"
+  show (Integral n) = "(Integral " ++ show n ++ ")"
   show (Fractional n) = "(Fractional " ++ show n ++ ")"
-  show (Date       d) = "(Date " ++ show d ++ ")"
-  show (DateTime   d) = "(DateTime " ++ show d ++ ")"
-  show (Time       d) = "(Time " ++ show d ++ ")"
-  show (Interval u v) = "(Interval " ++ show u ++ " " ++ show v ++ ")"
-  show (Text       s) = "(Text " ++ show s ++ ")"
-  show (Bool       b) = "(Bool " ++ show b ++ ")"
-  show (Percent    n) = "(Percent " ++ show n ++ ")"
-  show (Currency   n) = "(Currency " ++ show n ++ ")"
+  show (Date d) = "(Date " ++ toString d ++ ")"
+  show (DateTime d) = "(DateTime " ++ toString d ++ ")"
+  show (Time d) = "(Time " ++ timeRecToString d ++ ")"
+  show (Interval u v) = "(Interval " ++ toString u ++ " " ++ toString  v ++ ")"
+  show (Text s) = "(Text " ++ show s ++ ")"
+  show (Bool b) = "(Bool " ++ show b ++ ")"
+  show (Percent n) = "(Percent " ++ show n ++ ")"
+  show (Currency c n) = "(Currency " ++ show n ++ show c ++ ")"
   show (NA)           = "NA"
 
 instance eqJSemantic :: Eq JSemantic where
@@ -46,12 +74,16 @@ instance eqJSemantic :: Eq JSemantic where
   eq (Fractional a) (Fractional b) = a == b
   eq (Date       a) (Date       b) = a == b
   eq (DateTime   a) (DateTime   b) = a == b
-  eq (Time       a) (Time       b) = a == b
+  eq (Time       a) (Time       b) =
+    a.hours == b.hours &&
+    a.minutes == b.minutes &&
+    a.seconds == b.seconds &&
+    a.milliseconds == b.milliseconds
   eq (Interval u v) (Interval x y) = (u == x) && (v == y)
   eq (Text       a) (Text       b) = a == b
   eq (Bool       a) (Bool       b) = a == b
   eq (Percent    a) (Percent    b) = a == b
-  eq (Currency   a) (Currency   b) = a == b
+  eq (Currency c a) (Currency c' b) = a == b && c == c'
   eq (NA) (NA) = true
   eq _ _ = false
 
@@ -59,99 +91,156 @@ renderJSemantic :: JSemantic -> String
 renderJSemantic j = case j of
   (Integral   n) -> show n
   (Fractional n) -> show n
-  (Date       d) -> show d
-  (DateTime   d) -> show d
-  (Time       d) -> show d
-  (Interval u v) -> show u ++ " - " ++ show v
+  (Date       d) -> toString d
+  (DateTime   d) -> toString d
+  (Time       d) -> timeRecToString d
+  (Interval u v) -> toString u ++ " - " ++ toString v
   (Text       s) -> s
   (Bool       b) -> show b
   (Percent    n) -> show n ++ "%"
-  (Currency   n) -> "$" ++ show n
+  (Currency c n) -> show c ++ show n
   (NA)           -> ""
 
-type JSemanticRegexes =
-  { percent :: Regex
-  , currency :: Regex
-  , date :: Regex
-  }
 
-type JSemanticOpts = 
-  { regexps :: JSemanticRegexes
-  }
-
--- source: http://www.fileformat.info/info/unicode/category/Sc/list.htm
-currencySymbols :: String
-currencySymbols = """[\$\u20A0-\u20CF\u00A2\u00A3\u00A4\u00A5\u058F\u060B\u09F2\u09F3\u09FB\u0AF1\u0BF9\u0E3F\u17DB\uA838\uFDFC\uFE69\uFF04\uFFE0\uFFE1\uFFE5\uFFE6]"""
-
--- the first capture group will be used 
-currencyNums :: String
-currencyNums = """?(([0-9]{1,3},([0-9]{3},)*[0-9]{3}|[0-9]+)(.[0-9][0-9])?)$"""
-
-dateStr :: String
-dateStr = """^((\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})Z?[+-](\d{2})\:(\d{2}))$"""
-
-percentStr :: String
-percentStr = """^(-?\d+(\.\d+)?)\%$"""
-
-
-jSemanticOptsDefault :: JSemanticOpts
-jSemanticOptsDefault = 
-  { regexps: { percent: rx percentStr
-             , currency: rx $ "^" ++ currencySymbols ++ currencyNums
-             , date: rx dateStr
-             }
+type JSemanticParsers =
+  { boolParsers :: L.List (Boolean -> Maybe JSemantic) 
+  , numberParsers :: L.List (Number -> Maybe JSemantic)
+  , stringParsers :: L.List (String -> Maybe JSemantic)
   } 
+
+
 
 rx s = regex s noFlags
 rg s = regex s $ parseFlags "g"
 
-analyzeNum :: Number -> JSemantic
-analyzeNum n = maybe (Fractional n) Integral $ fromNumber n
-
+foreign import toString :: Date.Date -> String 
 
 foreign import s2nImpl :: (Number -> Maybe Number) -> Maybe Number -> String -> Maybe Number
 
 s2n :: String -> Maybe Number
 s2n = s2nImpl Just Nothing
 
-parseX :: forall a. Regex -> (String -> Maybe a) -> (a -> JSemantic) -> String ->
-          Maybe JSemantic
-parseX regexp parser constr s = do
-  matched <- match regexp s
-  s1 <- matched !! 1
-  constr <$> (s1 >>= parser)
 
-parsePercent :: Regex -> String -> Maybe JSemantic 
-parsePercent  r = parseX r s2n Percent
+-- source: http://www.fileformat.info/info/unicode/category/Sc/list.htm
+currencySymbols :: String
+currencySymbols = """([\$\u20A0-\u20CF\u00A2\u00A3\u00A4\u00A5\u058F\u060B\u09F2\u09F3\u09FB\u0AF1\u0BF9\u0E3F\u17DB\uA838\uFDFC\uFE69\uFF04\uFFE0\uFFE1\uFFE5\uFFE6])"""
 
-parseCurrency :: Regex -> String -> Maybe JSemantic
-parseCurrency r = parseX r (replace (rg ",") "" >>> s2n) Currency
+-- the first capture group will be used 
+currencyNums :: String
+currencyNums = """(([0-9]{1,3},([0-9]{3},)*[0-9]{3}|[0-9]+)(.[0-9][0-9])?)"""
 
-parseDateTime :: Regex -> String -> Maybe JSemantic
-parseDateTime r = parseX r Date.fromString DateTime 
+datetimeStr :: String
+datetimeStr = """^((\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})Z?[+-](\d{2})\:(\d{2}))$"""
 
-parseInterval :: Regex -> String -> Maybe JSemantic
-parseInterval r s = do
-  let arr = split " - " s
-  s1 <- arr !! 0
-  s2 <- arr !! 1
-  guard $ (test r s1) && (test r s2)
-  d1 <- Date.fromString s1
-  d2 <- Date.fromString s2
+timeStr :: String
+timeStr = """^([01]?[0-9]|2[0-3]):([0-5][0-9])(:([0-5][0-9]))*(.([0-9]{3}))*$"""
+
+percentStr :: String
+percentStr = """^(-?\d+(\.\d+)?)\%$"""
+
+integralNum :: Number -> Maybe JSemantic
+integralNum n = Integral <$> fromNumber n
+
+fractionalNum :: Number -> Maybe JSemantic
+fractionalNum n = pure $ Fractional n 
+
+percentString :: String -> Maybe JSemantic
+percentString str = do
+  matched <- match (rx percentStr) str
+  s1 <- matched A.!! 1 
+  num <- s1 >>= s2n 
+  pure $ Percent num
+
+currencyLeftString :: String -> Maybe JSemantic
+currencyLeftString str = do
+  matched <- match (rx $ "^" <> currencySymbols <> currencyNums <> "$") str
+  s1 <- matched A.!! 2 
+  cur <- matched A.!! 1 >>= id
+  num <- (replace (rg ",") "" <$> s1) >>= s2n
+  pure $ Currency cur num
+  
+currencyRightString :: String -> Maybe JSemantic
+currencyRightString str = do
+  matched <- match (rx $ "^" <> currencyNums <> currencySymbols <> "$") str
+  s1 <- matched A.!! 1 
+  cur <- matched A.!! 5 >>= id
+  num <- (replace (rg ",") "" <$> s1) >>= s2n
+  pure $ Currency cur num
+
+timeString :: String -> Maybe JSemantic
+timeString str = do
+  matched <- match (rx timeStr) str
+  h <- matched A.!! 1 >>= toInt
+  m <- matched A.!! 2 >>= toInt
+  let s = maybe zero Time.Seconds $ matched A.!! 4 >>= toInt
+      ms = maybe zero Time.Milliseconds $ matched A.!! 6 >>= toInt
+  pure $ Time { hours: Time.Hours h
+              , minutes: Time.Minutes m
+              , seconds: s
+              , milliseconds: ms
+              }
+  where toInt x = x >>= s2n >>= fromNumber
+
+datetimeString :: String -> Maybe JSemantic
+datetimeString str = do
+  matched <- match (rx datetimeStr) str
+  s1 <- matched A.!! 1 >>= id
+  DateTime <$> Date.fromString s1
+
+intervalString :: String -> Maybe JSemantic
+intervalString s = do
+  let arr :: Array String
+      arr = split " - " s
+  s1 <- arr A.!! 0 
+  s2 <- arr A.!! 1
+  (DateTime d1) <- datetimeString s1
+  (DateTime d2) <- datetimeString s2
   pure $ Interval d1 d2
 
--- analyzeStr :: {regexps} -> String -> JSemantic
-analyzeStr :: JSemanticRegexes -> String -> JSemantic
-analyzeStr rs s = fromMaybe (Text s) (    parsePercent rs.percent s
-                                      <|> parseCurrency rs.currency s
-                                      <|> parseDateTime rs.date s
-                                      <|> parseInterval rs.date s
-                                     )
-  -- TODO: date, time
+integralString :: String -> Maybe JSemantic
+integralString s = Integral <$> (s2n s >>= fromNumber)
 
-toSemantic :: JSemanticOpts -> JsonPrim -> JSemantic
-toSemantic o p = runJsonPrim p (const NA) Bool analyzeNum (analyzeStr o.regexps)
+fractionalString :: String -> Maybe JSemantic
+fractionalString s = Fractional <$> s2n s
+
+
+textString :: String -> Maybe JSemantic
+textString s = pure $ Text s
+
+
+stringParsers :: L.List (String -> Maybe JSemantic)
+stringParsers =
+  integralString L.:
+  fractionalString L.:
+  percentString L.:
+  currencyLeftString L.:
+  currencyRightString L.:
+  timeString L.:
+  datetimeString L.:
+  intervalString L.:
+  textString L.:
+  empty 
+
+
+defaultParsers :: JSemanticParsers
+defaultParsers =
+  { boolParsers: L.singleton (pure <<< Bool)
+  , numberParsers: integralNum L.: fractionalNum L.: empty
+  , stringParsers: stringParsers 
+  } 
+
+
+toSemantic :: JSemanticParsers -> JsonPrim -> JSemantic
+toSemantic o p = runJsonPrim p
+                 (const NA)
+                 (applyParsers o.boolParsers)
+                 (applyParsers o.numberParsers)
+                 (applyParsers o.stringParsers)
+  where
+  applyParsers :: forall a. L.List (a -> Maybe JSemantic) -> a -> JSemantic
+  applyParsers lst a =
+    fromMaybe NA $ runFirst $ fold (First <$> (($ a) <$> lst))
 
 toSemanticDef :: JsonPrim -> JSemantic
-toSemanticDef = toSemantic jSemanticOptsDefault
+toSemanticDef = toSemantic defaultParsers
 

--- a/test/Test/Data/Json/JSemantic.purs
+++ b/test/Test/Data/Json/JSemantic.purs
@@ -5,15 +5,20 @@ import Data.Maybe
 import Data.Argonaut.Core
 import Data.Argonaut.JCursor
 import Data.Json.JSemantic
+import Control.Monad.Eff.Console 
 
 import qualified Data.Date as D
+import Data.Time (Hours(..), Minutes(..), Seconds(..), Milliseconds(..))
 import Data.Argonaut.JCursor
 import Test.StrongCheck
 import Data.Maybe.Unsafe (fromJust)
 
 
-assertion msg prim expected =
-  assert ((toSemanticDef prim == expected) <?> msg)
+assertion msg prim expected = do
+  log msg
+  let actual = toSemanticDef prim
+      errMsg = "expected: " <> show expected <> "\nactual: " <> show actual
+  assert ((toSemanticDef prim == expected) <?> errMsg)
 
 d1 = "1981-04-01T06:55:00+02:00"
 d2 = "2022-12-31T07:14:00+01:00"
@@ -34,9 +39,27 @@ main = do
   assertion "percent 0.0%" (primStr "0.0%") (Percent 0.0)
   assertion "percent 13.91%" (primStr "13.91%") (Percent 13.91)
   assertion "percent -8.13%" (primStr "-8.13%") (Percent (-8.13))
-  assertion "currency $0" (primStr "$0") (Currency 0.0)
-  assertion "currency $1.23" (primStr "$1.23") (Currency 1.23)
-  assertion "currency $123,456.03" (primStr "$123,456.03") (Currency 123456.03)
-  assertion "currency $8,482,234" (primStr "$8,482,234") (Currency 8482234.0)
+  assertion "currency $0" (primStr "$0") (Currency "$" 0.0)
+  assertion "currency ¥12" (primStr "12¥") (Currency "¥" 12.0)
+  assertion "currency $1.23" (primStr "$1.23") (Currency "$" 1.23)
+  assertion "currency $123,456.03" (primStr "$123,456.03") (Currency "$" 123456.03)
+  assertion "currency $8,482,234" (primStr "$8,482,234") (Currency "$" 8482234.0)
   assertion "text" (primStr "$0%") (Text "$0%")
-
+  assertion "integral 100" (primStr "100") (Integral 100)
+  assertion "integral -100" (primStr "-100") (Integral (-100))
+  assertion "integral 100.00" (primStr "100.00") (Integral 100)
+  assertion "integral 0" (primStr "0") (Integral 0)
+  assertion "fractional 123.45" (primStr "123.45") (Fractional 123.45)
+  assertion "fractional -234.56" (primStr "-234.56") (Fractional (-234.56))
+  assertion "time 12:34:56" (primStr "12:34:56") (Time { hours: Hours 12
+                                                       , minutes: Minutes 34
+                                                       , seconds: Seconds 56
+                                                       , milliseconds: Milliseconds 0
+                                                       })
+  assertion "time 23:45:01.123" (primStr "23:45:01.123")
+    (Time { hours: Hours 23
+          , minutes: Minutes 45
+          , seconds: Seconds 1
+          , milliseconds: Milliseconds 123
+          })
+  assertion "incorrect time 56:12:12" (primStr "56:12:12") (Text "56:12:12")


### PR DESCRIPTION
fixes #18 

* added currency tag for `Currency` constructor ("$", "¥")
* added parsers from `String` to `Integral` and `Fractional`
* added parser from `String` to `Time` (not sure about `Date` constructor it can have many available formats) 
* reworked `type JSemanticOpts = {regexes: {currency: ..., percent: ..., etc...}}` 